### PR TITLE
feat(TQ5): wall types/textures

### DIFF
--- a/src/app/features/editor/ui/components/area-cell/area-cell.component.html
+++ b/src/app/features/editor/ui/components/area-cell/area-cell.component.html
@@ -7,36 +7,25 @@
   [style.width]="width"
   [style.height]="height"
 >
-  <!-- [style.opacity]="isSelected ? 1 : anyCellSelected ? 0.1 : 1" -->
-  <svg
-    id="area-cell-{{ cell?.y }}-{{ cell?.x }}--sides"
-    [attr.viewBox]="svgViewBox"
-    version="1.1"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlns:svg="http://www.w3.org/2000/svg"
-    style="position: absolute; bottom: 0; left: 0; width: 100%"
-  >
-    @if(displayElements.left) {
-    <polygon [attr.points]="svgPolygonPoints[0]" fill="#888" />
-    } @if(displayElements.right) {
-    <polygon [attr.points]="svgPolygonPoints[1]" fill="#999" />
-    }
-  </svg>
-
-  <!-- <svg
-    id="area-cell-{{ cell?.y }}-{{ cell?.x }}--sides"
-    [attr.viewBox]="svgViewBox"
-    version="1.1"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlns:svg="http://www.w3.org/2000/svg"
-    style="position: absolute; top: 0; left: 0; width: 100%; opacity: 0.25"
-  >
-    @if(displayElements.backLeft) {
-    <polygon [attr.points]="svgPolygonPoints[2]" fill="#ddd" />
-    } @if(displayElements.backRight) {
-    <polygon [attr.points]="svgPolygonPoints[3]" fill="#999" />
-    }
-  </svg> -->
+  <!-- WALL LEFT -->
+  @if(cell && displayElements.left) {
+  <app-textures-wall
+    [wallType]="cell.wallSouth"
+    wallPosition="l"
+    [svgPolygonPoints]="svgPolygonPoints"
+    [svgViewBox]="svgViewBox"
+  />
+  }
+  <!-- WALL RIGHT -->
+  @if(cell && displayElements.right) {
+  <app-textures-wall
+    [wallType]="cell.wallEast"
+    wallPosition="r"
+    [svgPolygonPoints]="svgPolygonPoints"
+    [svgViewBox]="svgViewBox"
+  />
+  }
+  <!-- FLOOR -->
   @if(cell && displayElements.top) {
   <app-textures-floor [floorType]="cell.floor" />
   }

--- a/src/app/features/editor/ui/components/area-cell/area-cell.component.ts
+++ b/src/app/features/editor/ui/components/area-cell/area-cell.component.ts
@@ -8,11 +8,12 @@ import {
 import { GameArea, GameAreaMapCell } from '@app/features/main/interfaces/types';
 import { defaultGridSize } from '@config/index';
 import { TexturesFloorComponent } from '@app/features/game/ui/components/textures/textures-floor/textures-floor.component';
+import { TexturesWallComponent } from '@app/features/game/ui/components/textures/textures-wall/textures-wall.component';
 
 @Component({
   selector: 'app-area-cell',
   standalone: true,
-  imports: [TexturesFloorComponent],
+  imports: [TexturesFloorComponent, TexturesWallComponent],
   templateUrl: './area-cell.component.html',
   styleUrl: './area-cell.component.css',
 })
@@ -34,9 +35,6 @@ export class AreaCellComponent {
   isSelected: boolean = false;
   anyCellSelected: boolean = false;
   selectedCell: GameAreaMapCell | null = null;
-  floorTexture: string = '';
-  wallLeftTexture: string = '';
-  wallRightTexture: string = '';
   displayElements: {
     top: boolean;
     left: boolean;
@@ -75,9 +73,6 @@ export class AreaCellComponent {
         backLeft: false,
         backRight: false,
       };
-
-      this.floorTexture = `url(#texture-${this.cell.floor ?? 'default'})`;
-      // const wall = wallDefinitions.find((item) => item.id === this.cell.wall);
     }
   }
 

--- a/src/app/features/editor/ui/components/editor-panel-cells/editor-panel-cells.component.html
+++ b/src/app/features/editor/ui/components/editor-panel-cells/editor-panel-cells.component.html
@@ -96,6 +96,7 @@
     <div class="flex flex-col gap-4">
       <label>Floor: {{ currentFloorOption || "None" }}</label>
       <app-editor-texture-selector
+        surfaceType="floor"
         [options]="floorOptions"
         [selectedId]="selectedCell.floor"
         (onSelect)="handleFloorChange($event)"
@@ -105,6 +106,7 @@
       <label>Wall Left: {{ currentWallLOption || "None" }}</label>
       <app-editor-texture-selector
         [options]="wallOptions"
+        surfaceType="wall"
         [selectedId]="selectedCell.wallSouth"
         (onSelect)="handleWallChange($event, 'south')"
       />
@@ -114,6 +116,7 @@
       <label>Wall Right: {{ currentWallROption || "None" }}</label>
       <app-editor-texture-selector
         [options]="wallOptions"
+        surfaceType="wall"
         [selectedId]="selectedCell.wallEast"
         (onSelect)="handleWallChange($event, 'east')"
       />

--- a/src/app/features/editor/ui/components/editor-texture-selector/editor-texture-selector.component.html
+++ b/src/app/features/editor/ui/components/editor-texture-selector/editor-texture-selector.component.html
@@ -10,7 +10,17 @@
     [attr.aria-label]="option.name"
     [attr.title]="option.name"
   >
+    @if(surfaceType === 'floor') {
     <app-textures-floor [floorType]="option.id" [isFlat]="true" />
+    } @else {
+    <app-textures-wall
+      [wallType]="option.id"
+      [isFlat]="true"
+      [svgPolygonPoints]="['0,0 100,0 100,100 0,100', '']"
+      wallPosition="l"
+      svgViewBox="0 0 50 100"
+    />
+    }
   </button>
   }
 </div>

--- a/src/app/features/editor/ui/components/editor-texture-selector/editor-texture-selector.component.ts
+++ b/src/app/features/editor/ui/components/editor-texture-selector/editor-texture-selector.component.ts
@@ -1,14 +1,16 @@
 import { Component, Output, Input, EventEmitter } from '@angular/core';
 import { TexturesFloorComponent } from '@app/features/game/ui/components/textures/textures-floor/textures-floor.component';
+import { TexturesWallComponent } from '@app/features/game/ui/components/textures/textures-wall/textures-wall.component';
 
 @Component({
   selector: 'app-editor-texture-selector',
   standalone: true,
-  imports: [TexturesFloorComponent],
+  imports: [TexturesFloorComponent, TexturesWallComponent],
   templateUrl: './editor-texture-selector.component.html',
   styleUrl: './editor-texture-selector.component.css',
 })
 export class EditorTextureSelectorComponent {
+  @Input('surfaceType') surfaceType: string = 'floor';
   @Input('selectedId') selectedId: string = '';
   @Input('options') options: { id: string; name: string }[] = [
     {

--- a/src/app/features/game/ui/components/textures/textures-floor/textures-floor.component.html
+++ b/src/app/features/game/ui/components/textures/textures-floor/textures-floor.component.html
@@ -7,17 +7,27 @@
 >
   <defs>
     @if(floorType === 'dirt') {
-    <linearGradient id="grad1">
-      <stop offset="0%" stop-color="white" />
-      <stop offset="100%" stop-color="red" />
-    </linearGradient>
-    <pattern id="texture-dirt" x="0" y="0" width="0.25" height="0.25">
-      <rect x="0" y="0" width="50" height="50" fill="lightblue" />
-      <circle cx="25" cy="25" r="20" fill="url(#grad1)" fill-opacity="0.8" />
+    <pattern
+      [id]="'texture_floor_dirt_' + (isFlat ? 'flat' : 'floor')"
+      x="0"
+      y="0"
+      width="1"
+      [attr.height]="isFlat ? '0.5' : '1'"
+    >
+      <rect x="0" y="0" width="100" height="100" fill="#5f4126" />
+      <ellipse cx="30" cy="18" rx="4" ry="2" fill="#543109" />
+      <ellipse cx="75" cy="30" rx="4" ry="2" fill="#543109" />
+
+      <circle cx="43" cy="40" r="2" fill="#7b5a36" />
+      <circle cx="60" cy="20" r="2" fill="#543109" />
+      <circle cx="50" cy="7" r="1" fill="#7b5a36" />
+      <circle cx="56" cy="37" r="1" fill="#7b5a36" />
+      <circle cx="85" cy="22" r="1" fill="#7b5a36" />
+      <circle cx="10" cy="26" r="1" fill="#7b5a36" />
     </pattern>
     } @else if(floorType === 'water') {
     <pattern
-      [id]="'texture-water_' + (isFlat ? 'flat' : 'floor')"
+      [id]="'texture_floor_water_' + (isFlat ? 'flat' : 'floor')"
       x="0"
       y="0"
       width="1"
@@ -40,17 +50,47 @@
     </pattern>
     } @else if(floorType === 'wall-top') {
     <pattern
-      [id]="'texture-wall-top_' + (isFlat ? 'flat' : 'floor')"
+      [id]="'texture_floor_wall-top_' + (isFlat ? 'flat' : 'floor')"
       x="0"
       y="0"
       width="1"
       [attr.height]="isFlat ? '0.25' : '1'"
     >
       <rect x="0" y="0" width="100" height="100" fill="#ccc" />
+      <ellipse
+        cx="25"
+        cy="30"
+        rx="3"
+        ry="1.5"
+        fill="none"
+        stroke="#aaa"
+        strokeWidth="1"
+      />
+      <ellipse
+        cx="60"
+        cy="38"
+        rx="3"
+        ry="1.5"
+        fill="none"
+        stroke="#aaa"
+        strokeWidth="1"
+      />
+      <ellipse
+        cx="50"
+        cy="10"
+        rx="3"
+        ry="1.5"
+        fill="none"
+        stroke="#aaa"
+        strokeWidth="1"
+      />
+      <circle cx="75" cy="20" r="1" fill="#aaa" />
+      <circle cx="50" cy="26" r="1" fill="#aaa" />
+      <circle cx="26" cy="22" r="1" fill="#aaa" />
     </pattern>
     } @else if(floorType === 'tile-dark') {
     <pattern
-      [id]="'texture-tile-dark_' + (isFlat ? 'flat' : 'floor')"
+      [id]="'texture_floor_tile-dark_' + (isFlat ? 'flat' : 'floor')"
       x="0"
       y="0"
       width="1"
@@ -67,7 +107,7 @@
     </pattern>
     } @else {
     <pattern
-      [id]="'texture-default_' + (isFlat ? 'flat' : 'floor')"
+      [id]="'texture_floor_default_' + (isFlat ? 'flat' : 'floor')"
       x="0"
       y="0"
       width="1"
@@ -89,7 +129,11 @@
       isFlat ? '0,0 100,0 100,100 0,100' : '50,0 100,25 50,50 0,25'
     "
     [attr.fill]="
-      'url(#texture-' + floorType + '_' + (isFlat ? 'flat' : 'floor') + ')'
+      'url(#texture_floor_' +
+      floorType +
+      '_' +
+      (isFlat ? 'flat' : 'floor') +
+      ')'
     "
   />
 </svg>

--- a/src/app/features/game/ui/components/textures/textures-floor/textures-floor.component.ts
+++ b/src/app/features/game/ui/components/textures/textures-floor/textures-floor.component.ts
@@ -10,5 +10,4 @@ import { Component, Input } from '@angular/core';
 export class TexturesFloorComponent {
   @Input('floorType') floorType: string = 'default';
   @Input('isFlat') isFlat: boolean = false;
-  floorTexture: string = `url(#texture-${this.floorType ?? 'default'})`;
 }

--- a/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.css
+++ b/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.css
@@ -1,0 +1,37 @@
+.default {
+  &.wall-position-l {
+    .bgRect {
+      fill: #999;
+    }
+    .brick {
+      stroke: #888;
+    }
+  }
+  &.wall-position-r {
+    .bgRect {
+      fill: #888;
+    }
+    .brick {
+      stroke: #777;
+    }
+  }
+}
+
+.dark-stone {
+  &.wall-position-l {
+    .bgRect {
+      fill: #444;
+    }
+    .brick {
+      stroke: #666;
+    }
+  }
+  &.wall-position-r {
+    .bgRect {
+      fill: #333;
+    }
+    .brick {
+      stroke: #555;
+    }
+  }
+}

--- a/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.html
+++ b/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.html
@@ -1,0 +1,107 @@
+<svg
+  [attr.viewBox]="svgViewBox"
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:svg="http://www.w3.org/2000/svg"
+  style="position: absolute; bottom: 0; left: 0; width: 100%"
+  [attr.class]="wallType + ' wall-position-' + wallPosition"
+>
+  <defs>
+    @if(wallType === 'test') {
+    <pattern
+      [id]="
+        'texture_' +
+        wallType +
+        '_' +
+        wallPosition +
+        '_' +
+        (isFlat ? 'flat' : 'wall')
+      "
+      x="0"
+      y="0"
+      width="1"
+      height="1"
+    >
+      <rect
+        x="0"
+        y="0"
+        width="100%"
+        height="100%"
+        [attr.fill]="wallPosition === 'l' ? '#999' : '#888'"
+      />
+      @if(wallPosition === 'l') { } @else { }
+    </pattern>
+    } @else {
+    <pattern
+      [id]="
+        'texture_' +
+        wallType +
+        '_' +
+        wallPosition +
+        '_' +
+        (isFlat ? 'flat' : 'wall')
+      "
+      x="0"
+      y="0"
+      width="1"
+      height="1"
+    >
+      <rect x="0" y="0" width="100" height="400" class="bgRect" />
+      @if(wallPosition === 'l') {
+      <line x1="0" y1="25" x2="50" y2="50" class="brick" strokeWidth="2" />
+      <line x1="0" y1="50" x2="50" y2="75" class="brick" strokeWidth="2" />
+      <line x1="0" y1="75" x2="50" y2="100" class="brick" strokeWidth="2" />
+      <line x1="0" y1="100" x2="50" y2="125" class="brick" strokeWidth="2" />
+      <line x1="0" y1="125" x2="50" y2="150" class="brick" strokeWidth="2" />
+      <line x1="0" y1="150" x2="50" y2="175" class="brick" strokeWidth="2" />
+      <line x1="0" y1="175" x2="50" y2="200" class="brick" strokeWidth="2" />
+      <line x1="0" y1="200" x2="50" y2="225" class="brick" strokeWidth="2" />
+      <line x1="0" y1="225" x2="50" y2="250" class="brick" strokeWidth="2" />
+      <line x1="0" y1="250" x2="50" y2="275" class="brick" strokeWidth="2" />
+      <line x1="0" y1="275" x2="50" y2="300" class="brick" strokeWidth="2" />
+
+      <line x1="25" y1="13" x2="25" y2="38" class="brick" strokeWidth="2" />
+      <line x1="10" y1="30" x2="10" y2="55" class="brick" strokeWidth="2" />
+      <line x1="25" y1="63" x2="25" y2="88" class="brick" strokeWidth="2" />
+      <line x1="10" y1="80" x2="10" y2="105" class="brick" strokeWidth="2" />
+      <line x1="25" y1="113" x2="25" y2="138" class="brick" strokeWidth="2" />
+      <line x1="10" y1="130" x2="10" y2="155" class="brick" strokeWidth="2" />
+      <line x1="25" y1="163" x2="25" y2="188" class="brick" strokeWidth="2" />
+      <line x1="10" y1="180" x2="10" y2="205" class="brick" strokeWidth="2" />
+      <line x1="25" y1="213" x2="25" y2="238" class="brick" strokeWidth="2" />
+      <line x1="10" y1="230" x2="10" y2="255" class="brick" strokeWidth="2" />
+      } @else {
+      <line x1="0" y1="50" x2="50" y2="25" class="brick" strokeWidth="2" />
+      <line x1="0" y1="75" x2="50" y2="50" class="brick" strokeWidth="2" />
+      <line x1="0" y1="100" x2="50" y2="75" class="brick" strokeWidth="2" />
+      <line x1="0" y1="125" x2="50" y2="100" class="brick" strokeWidth="2" />
+      <line x1="0" y1="150" x2="50" y2="125" class="brick" strokeWidth="2" />
+      <line x1="0" y1="175" x2="50" y2="150" class="brick" strokeWidth="2" />
+      <line x1="0" y1="200" x2="50" y2="175" class="brick" strokeWidth="2" />
+      <line x1="0" y1="225" x2="50" y2="200" class="brick" strokeWidth="2" />
+      <line x1="0" y1="250" x2="50" y2="225" class="brick" strokeWidth="2" />
+      <line x1="0" y1="275" x2="50" y2="250" class="brick" strokeWidth="2" />
+      <line x1="0" y1="300" x2="50" y2="275" class="brick" strokeWidth="2" />
+
+      <line x1="25" y1="13" x2="25" y2="38" class="brick" strokeWidth="2" />
+      <line x1="10" y1="44" x2="10" y2="69" class="brick" strokeWidth="2" />
+      <line x1="25" y1="63" x2="25" y2="88" class="brick" strokeWidth="2" />
+      <line x1="10" y1="94" x2="10" y2="119" class="brick" strokeWidth="2" />
+      <line x1="25" y1="113" x2="25" y2="138" class="brick" strokeWidth="2" />
+      <line x1="10" y1="144" x2="10" y2="169" class="brick" strokeWidth="2" />
+      <line x1="25" y1="163" x2="25" y2="188" class="brick" strokeWidth="2" />
+      <line x1="10" y1="194" x2="10" y2="219" class="brick" strokeWidth="2" />
+      <line x1="25" y1="213" x2="25" y2="238" class="brick" strokeWidth="2" />
+      <line x1="10" y1="244" x2="10" y2="269" class="brick" strokeWidth="2" />
+
+      }
+    </pattern>
+    }
+  </defs>
+
+  @if(wallPosition === 'l') {
+  <polygon [attr.points]="svgPolygonPoints[0]" [attr.fill]="wallTexture" />
+  } @if(wallPosition === 'r') {
+  <polygon [attr.points]="svgPolygonPoints[1]" [attr.fill]="wallTexture" />
+  }
+</svg>

--- a/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.spec.ts
+++ b/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TexturesWallComponent } from './textures-wall.component';
+
+describe('TexturesWallComponent', () => {
+  let component: TexturesWallComponent;
+  let fixture: ComponentFixture<TexturesWallComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TexturesWallComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TexturesWallComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.ts
+++ b/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.ts
@@ -1,0 +1,25 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-textures-wall',
+  standalone: true,
+  imports: [],
+  templateUrl: './textures-wall.component.html',
+  styleUrl: './textures-wall.component.css',
+})
+export class TexturesWallComponent {
+  @Input('wallType') wallType: string = 'default';
+  @Input('wallPosition') wallPosition: string = 'l';
+  @Input('svgViewBox') svgViewBox: string = '';
+  @Input('svgPolygonPoints') svgPolygonPoints: string[] = [];
+  @Input('isFlat') isFlat: boolean = false;
+  h: number = 100;
+  w: number = 100;
+  wallTexture: string = '';
+
+  ngOnInit() {
+    this.wallTexture = `url(#texture_${this.wallType}_${this.wallPosition}_${
+      this.isFlat ? 'flat' : 'wall'
+    })`;
+  }
+}

--- a/src/content/wall-definitions.ts
+++ b/src/content/wall-definitions.ts
@@ -1,23 +1,19 @@
 export type WallDefinition = {
   id: string;
   name: string;
-  texture: string;
 };
 
 export const wallDefinitions: WallDefinition[] = [
   {
     id: 'default',
-    name: 'Default',
-    texture: 'wall-default.svg',
+    name: 'Stone',
   },
   {
-    id: 'stone',
-    name: 'Stone',
-    texture: 'wall-stone.svg',
+    id: 'dark-stone',
+    name: 'Dark Stone',
   },
   {
     id: 'cave',
     name: 'Cave Wall',
-    texture: 'wall-cave.svg',
   },
 ];


### PR DESCRIPTION
### TQ5: Game Editor Wall Textures

- Branch: TQ5-Game-Editor-Wall-Textures
- [x] Add wall types (textures) for default and "dark stone" for demo room
- [x] make sure textures line up between walls and around corners
- [x] Update wall selector to include these wall types
- [x] Update dirt floor texture to use 0.5 aspect ratio ellipses rather than circles
