### PR TITLE
feat: TQ12 player movement

### DIFF
--- a/src/app/features/game/services/game-service/game-service.service.spec.ts
+++ b/src/app/features/game/services/game-service/game-service.service.spec.ts
@@ -88,3 +88,39 @@ describe('initGameState', () => {
     service.initGameState(gameMock);
   });
 });
+
+describe('processTurn', () => {
+  let service: GameService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GameService);
+
+    service.testInit(gameMock);
+  });
+
+  it('should process turn', fakeAsync(() => {
+    let i = 0;
+    tick(1000);
+    service.processTurn({
+      verb: 'move',
+      noun: '6_3',
+    });
+    tick(1000);
+
+    service.isLockedOutObs.subscribe((isLockedOut) => {
+      if (i === 0) {
+        expect(isLockedOut).toEqual(false);
+      }
+      if (i === 1) {
+        expect(isLockedOut).toEqual(true);
+      }
+      i += 1;
+    });
+
+    service.gameStateObs.subscribe((gameState) => {
+      expect(gameState?.player?.x).toEqual(3);
+      expect(gameState?.player?.y).toEqual(6);
+      expect(gameState?.player?.facing).toEqual('W');
+    });
+  }));
+});

--- a/src/app/features/game/services/game-service/game-service.service.ts
+++ b/src/app/features/game/services/game-service/game-service.service.ts
@@ -9,6 +9,7 @@ import {
 import { gamesApiUrl } from '@config/index';
 import { getMoveOptions } from './utils/pathfinding';
 import { STANDARD_MOVE_DURATION } from '@config/index';
+import gameMockData from '@app/features/editor/mocks/game.mock.json';
 
 @Injectable({
   providedIn: 'root',
@@ -26,6 +27,10 @@ export class GameService {
   private isLockedOut = new BehaviorSubject<boolean>(false);
   isLockedOutObs = this.isLockedOut.asObservable();
 
+  testInit(nextGameROM: GameROM): void {
+    this.gameROM.next(nextGameROM);
+    this.initGameState(nextGameROM);
+  }
   calculateMovementOptions(
     nextGameROM: GameROM,
     nextGameState: GameState
@@ -130,10 +135,8 @@ export class GameService {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  turnActionMovePlayer = async (
-    destinationPositionKey: string
-  ): Promise<GameState> => {
-    const path = this.movementOptions.value[destinationPositionKey];
+  turnActionMovePlayer = async (destination: string): Promise<GameState> => {
+    const path = this.movementOptions.value[destination];
     let nextGameState = JSON.parse(JSON.stringify(this.gameState.value));
     if (!path || path.length < 2) {
       return this.gameState.value as GameState;
@@ -157,9 +160,8 @@ export class GameService {
       }
       this.gameState.next(nextGameState);
       await this.delay(STANDARD_MOVE_DURATION);
-      // setTimeout(() => {
-      // }, 2000);
     }
+    await this.delay(500);
     this.isLockedOut.next(false);
     return this.gameState.value as GameState;
   };
@@ -178,7 +180,6 @@ export class GameService {
       switch (verb) {
         case 'move':
           // move logic
-          // -- noun is positionKey and we need to pass in the path from movement options
           nextGameState = await this.turnActionMovePlayer(noun);
           break;
         default:

--- a/src/app/features/game/ui/components/game-area/game-area.component.html
+++ b/src/app/features/game/ui/components/game-area/game-area.component.html
@@ -27,23 +27,29 @@
     <app-area-item [item]="item" />
     }
 
-    <app-game-player
-      [playerPosition]="playerPosition"
-      [cellData]="areaMap[playerPosition]"
-    />
-
     <!-- Area Exits -->
     @for(exit of areaExits; track exit.id;) {
     <app-area-exit [exit]="exit" />
     }
 
     <!-- Movement Option Buttons -->
-    @for(moveOption of movementOptionsKeys; track moveOption;) {
+    @for(moveOption of movementOptionsKeys; track moveOption; let idx = $index)
+    {
     <app-game-movement-option-button
       [positionKey]="moveOption"
       [h]="areaMap[moveOption].h"
+      [isLockedOut]="isLockedOut"
+      [playerPosition]="playerPosition"
     />
     }
+
+    <app-game-player
+      [playerPosition]="playerPosition"
+      [cellData]="areaMap[playerPosition]"
+      [playerFacing]="playerFacing"
+    />
+
+    <div class="absolute right-2 top-2">Turns: {{ numTurns }}</div>
   </div>
   }
 </div>

--- a/src/app/features/game/ui/components/game-area/game-area.component.ts
+++ b/src/app/features/game/ui/components/game-area/game-area.component.ts
@@ -7,6 +7,7 @@ import {
   GameAreaMap,
   GameItem,
   GameState,
+  MovementOptions,
 } from '@app/features/main/interfaces/types';
 import { AreaCellComponent } from '@app/features/game/ui/components/area-cell/area-cell.component';
 import { AreaExitComponent } from '@app/features/game/ui/components/area-exit/area-exit.component';
@@ -39,17 +40,28 @@ export class GameAreaComponent {
   movementOptionsKeys: string[] = [];
   areaDataPositionKeys: string[] = [];
   playerPosition: string = '0_0';
+  playerFacing: string = 'n';
+  isLockedOut: boolean = false;
+  numTurns: number = 0;
 
   ngOnInit(): void {
     this.subscriptions.push(
-      this._gameService.movementOptionsObs.subscribe((data) => {
-        this.movementOptions = data;
-        this.movementOptionsKeys = Object.keys(data);
+      this._gameService.isLockedOutObs.subscribe((data: boolean) => {
+        this.isLockedOut = data;
       })
+    );
+    this.subscriptions.push(
+      this._gameService.movementOptionsObs.subscribe(
+        (data: MovementOptions) => {
+          this.movementOptions = data;
+          this.movementOptionsKeys = Object.keys(data);
+        }
+      )
     );
     this.subscriptions.push(
       this._gameService.gameStateObs.subscribe((data: GameState | null) => {
         if (data) {
+          this.numTurns = data.numTurns;
           if (data.player.areaId !== this.areaId) {
             const areaId = data.player.areaId;
             const area = this._gameService.getArea(areaId);
@@ -61,6 +73,7 @@ export class GameAreaComponent {
               : [];
           }
           this.playerPosition = `${data.player.y}_${data.player.x}`;
+          this.playerFacing = data.player.facing;
         }
       })
     );

--- a/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.css
+++ b/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.css
@@ -3,10 +3,10 @@
   pointer-events: none;
   &.locked-out {
     pointer-events: none;
-    opacity: 0.25;
+    opacity: 0.1;
   }
   opacity: 1;
-  transition: 0.1s opacity ease-in-out;
+  transition: 0.02s opacity ease-in-out;
   polygon {
     pointer-events: all;
   }

--- a/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.css
+++ b/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.css
@@ -1,17 +1,13 @@
 .movement-option-button {
   position: absolute;
   pointer-events: none;
+  &.locked-out {
+    pointer-events: none;
+    opacity: 0.25;
+  }
+  opacity: 1;
+  transition: 0.1s opacity ease-in-out;
   polygon {
     pointer-events: all;
-    /* fill: transparent; */
-    /* stroke-width: 2px;
-    stroke: transparent; */
-    /* transition: 0.3s stroke ease-in-out; */
-
-    /* &:focus,
-    &:hover {
-      outline: none;
-      stroke: var(--color-primary);
-    } */
   }
 }

--- a/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.html
+++ b/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.html
@@ -1,11 +1,12 @@
 <div
   id="movement-option-button-{{ y }}-{{ x }}"
-  class="movement-option-button"
+  class="movement-option-button {{ isLockedOut ? 'locked-out' : '' }}"
   [style.bottom]="position.bottom"
   [style.left]="position.left"
   [style.width]="width"
   [style.height]="height"
   [style.z-index]="z"
+  [style.transition-delay]="transformDelay"
 >
   <svg
     id="movement-option-button-{{ y }}-{{ x }}--svg"
@@ -22,7 +23,7 @@
         fill="none"
         points="50,0 100,25 50,50 0,25"
         (click)="handleMovementButtonClick()"
-        tabindex="0"
+        [attr.tabindex]="isLockedOut ? -1 : 0"
       />
       <ellipse
         cx="50"

--- a/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.html
+++ b/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.html
@@ -28,9 +28,9 @@
       <ellipse
         cx="50"
         cy="25"
-        rx="16"
-        ry="8"
-        fill="rgba(255,255,255,0.25)"
+        rx="8"
+        ry="4"
+        fill="var(--color-primary)"
         stroke="var(--color-primary-dark)"
         stroke-width="1"
         class="transition-all duration-[0.25s] opacity-75 group-hover:opacity-100 group-hover:fill-[rgba(255,255,255,1)] group-active:fill-[var(--color-primary)]"

--- a/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.ts
+++ b/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.ts
@@ -1,7 +1,9 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { defaultGridSize } from '@config/index';
-import { AreaPosition } from '@app/features/game/lib/utils';
-import { getAreaElementPositionStyle } from '@app/features/game/lib/utils';
+import { AreaPosition } from '@game/lib/utils';
+import { getAreaElementPositionStyle } from '@game/lib/utils';
+import { GameService } from '@game/services/game-service/game-service.service';
+import { getHeuristicDistance } from '@game/services/game-service/utils/pathfinding';
 
 @Component({
   selector: 'app-game-movement-option-button',
@@ -13,17 +15,28 @@ import { getAreaElementPositionStyle } from '@app/features/game/lib/utils';
 export class GameMovementOptionButtonComponent {
   @Input('positionKey') positionKey: string = '0_0';
   @Input('h') h: number = 1;
+  @Input('isLockedOut') isLockedOut: boolean = false;
+  @Input('playerPosition') playerPosition: string = '0_0';
+  @Output() HandleMovementClick = new EventEmitter<string>();
 
   x: number = 0;
   y: number = 0;
   z: number = 0;
+  transformDelay: string = '0s';
   title: string = '';
   gridSize: number = defaultGridSize;
   position: AreaPosition = { left: '0', bottom: '0', z: 0 };
   height: string = '0%';
   width: string = '0%';
 
+  constructor(private _gameService: GameService) {}
+
   ngOnInit() {
+    const distance = getHeuristicDistance(
+      this.positionKey,
+      this.playerPosition
+    );
+    this.transformDelay = `${distance * 0.05}s`;
     this.updateCellProps();
   }
 
@@ -45,6 +58,6 @@ export class GameMovementOptionButtonComponent {
   // -- verb: move
   // -- noun: positionKey
   handleMovementButtonClick() {
-    console.log('Move to positionKey:', this.positionKey);
+    this._gameService.processTurn({ verb: 'move', noun: this.positionKey });
   }
 }

--- a/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.ts
+++ b/src/app/features/game/ui/components/game-movement-option-button/game-movement-option-button.component.ts
@@ -14,6 +14,7 @@ import { getHeuristicDistance } from '@game/services/game-service/utils/pathfind
 })
 export class GameMovementOptionButtonComponent {
   @Input('positionKey') positionKey: string = '0_0';
+  @Input('destinationPositionKey') destinationPositionKey: string = '';
   @Input('h') h: number = 1;
   @Input('isLockedOut') isLockedOut: boolean = false;
   @Input('playerPosition') playerPosition: string = '0_0';
@@ -32,11 +33,6 @@ export class GameMovementOptionButtonComponent {
   constructor(private _gameService: GameService) {}
 
   ngOnInit() {
-    const distance = getHeuristicDistance(
-      this.positionKey,
-      this.playerPosition
-    );
-    this.transformDelay = `${distance * 0.05}s`;
     this.updateCellProps();
   }
 
@@ -45,6 +41,7 @@ export class GameMovementOptionButtonComponent {
     this.x = parseInt(positionKeyArr[1]);
     this.y = parseInt(positionKeyArr[0]);
     this.z = this.x * this.y + this.x + 1;
+    this.transformDelay = `${this.z * 0.01}s`;
     this.title = `Move to ${this.x}, ${this.y}`;
     const cellW = 100 / this.gridSize;
     const cellH = 100 / this.gridSize / 2;
@@ -54,10 +51,9 @@ export class GameMovementOptionButtonComponent {
     const svgH = (this.h + 1) * 25;
   }
 
-  // Handle click processturn
-  // -- verb: move
-  // -- noun: positionKey
   handleMovementButtonClick() {
-    this._gameService.processTurn({ verb: 'move', noun: this.positionKey });
+    if (!this.isLockedOut) {
+      this._gameService.processTurn({ verb: 'move', noun: this.positionKey });
+    }
   }
 }

--- a/src/app/features/game/ui/components/game-player/game-player.component.css
+++ b/src/app/features/game/ui/components/game-player/game-player.component.css
@@ -1,4 +1,7 @@
 .player-position {
   position: absolute;
   pointer-events: none;
+  transition-property: all;
+  transition-duration: 0.1s;
+  transition-timing-function: linear;
 }

--- a/src/app/features/game/ui/components/game-player/game-player.component.css
+++ b/src/app/features/game/ui/components/game-player/game-player.component.css
@@ -1,7 +1,4 @@
 .player-position {
   position: absolute;
   pointer-events: none;
-  transition-property: all;
-  transition-duration: 0.1s;
-  transition-timing-function: linear;
 }

--- a/src/app/features/game/ui/components/game-player/game-player.component.html
+++ b/src/app/features/game/ui/components/game-player/game-player.component.html
@@ -1,10 +1,13 @@
 <div
   [style.width]="width"
   [style.height]="width"
-  [style.z-index]="positionStyle.z"
+  [style.z-index]="positionStyle.z + 100"
   class="player-position"
   [style.bottom]="positionStyle.bottom"
   [style.left]="positionStyle.left"
 >
   <app-svg-player />
+  <div class="absolute top-8 left-0 w-full flex justify-center text-wite-100">
+    <div>{{ playerFacing }}</div>
+  </div>
 </div>

--- a/src/app/features/game/ui/components/game-player/game-player.component.html
+++ b/src/app/features/game/ui/components/game-player/game-player.component.html
@@ -1,7 +1,7 @@
 <div
   [style.width]="width"
   [style.height]="width"
-  [style.z-index]="positionStyle.z + 100"
+  [style.z-index]="positionStyle.z + 1"
   class="player-position"
   [style.bottom]="positionStyle.bottom"
   [style.left]="positionStyle.left"

--- a/src/app/features/game/ui/components/game-player/game-player.component.ts
+++ b/src/app/features/game/ui/components/game-player/game-player.component.ts
@@ -16,6 +16,7 @@ import { GameAreaMapCell } from '@app/features/main/interfaces/types';
 })
 export class GamePlayerComponent {
   @Input('playerPosition') playerPosition: string = '0_0';
+  @Input('playerFacing') playerFacing: string = 'n';
   @Input('cellData') cellData: GameAreaMapCell | null = null;
 
   h: number = 0;
@@ -29,7 +30,7 @@ export class GamePlayerComponent {
     if (this.cellData) {
       this.h = this.cellData.h;
     }
-    const [x, y] = this.playerPosition.split('_').map((v) => parseInt(v));
+    const [y, x] = this.playerPosition.split('_').map((v) => parseInt(v));
     const cellW = 100 / defaultGridSize;
     this.width = `${cellW}%`;
 

--- a/src/app/features/game/ui/pages/game/game.component.html
+++ b/src/app/features/game/ui/pages/game/game.component.html
@@ -17,7 +17,6 @@
     </app-container>
     <div class="game-wrap">
       <app-game-area />
-      <div class="absolute right-2 top-2">HUD GOES HERE</div>
     </div>
   </div>
 </app-main-layout>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,4 +5,4 @@ export const usersApiUrl = `${baseApiUrl}/users`;
 export const gamesApiUrl = `${baseApiUrl}/games`;
 export const defaultGridSize = 7;
 export const maxAreaCellHeight = 10;
-export const STANDARD_MOVE_DURATION = 100;
+export const STANDARD_MOVE_DURATION = 50;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,3 +5,4 @@ export const usersApiUrl = `${baseApiUrl}/users`;
 export const gamesApiUrl = `${baseApiUrl}/games`;
 export const defaultGridSize = 7;
 export const maxAreaCellHeight = 10;
+export const STANDARD_MOVE_DURATION = 100;


### PR DESCRIPTION
### TQ12: Player Movement

- Branch: TQ12-player-movement
- [x] Add a lockout boolean to game service to halt interactivity
- [x] When a movement turn is initiated, set up a timed display of the player moving from point A to B
- [x] Add an FPO indication of which direction the player is facing, not final art
  - All art is APO: Idle and walk animations will be
- [x] When movement is complete interactivity returns