### PR TITLE
feat: TQ15b editor items, exits: reset selection on click

### DIFF
--- a/src/app/features/editor/ui/components/editor-area/editor-area.component.ts
+++ b/src/app/features/editor/ui/components/editor-area/editor-area.component.ts
@@ -96,7 +96,6 @@ export class EditorAreaComponent {
     );
     this.subscriptions.push(
       this._gameEditorService.selectedAreaIdObs.subscribe((data: string) => {
-        console.log('SUBSCRIPTION: selectedAreaIdObs', data);
         this.selectedAreaId = data;
         this.selectedArea =
           this.game?.content.areas[this.selectedAreaId] ?? null;
@@ -144,11 +143,9 @@ export class EditorAreaComponent {
     this.clearCellSelection();
   }
   handleExitClick(id: string) {
-    console.log('AREA EDIT: handleExitClick', id);
     this.onSelectExit.emit(id);
   }
   handleItemClick(id: string) {
-    console.log('AREA EDIT: handleItemClick', id);
     this.onSelectItem.emit(id);
   }
 }

--- a/src/app/features/editor/ui/components/editor-panel-exits/editor-panel-exits.component.ts
+++ b/src/app/features/editor/ui/components/editor-panel-exits/editor-panel-exits.component.ts
@@ -84,7 +84,6 @@ export class EditorPanelExitsComponent {
   ngOnInit() {
     this.subscriptions.push(
       this._gameEditorService.selectedExitIdObs.subscribe((data: string) => {
-        console.log('SUBSCRIPTION: selectedExitId', data);
         this.selectedExitId = data;
         this.exits = this._gameEditorService.getExitsForCurrentArea();
         this.updateUiAfterExitSelection(data);
@@ -92,7 +91,6 @@ export class EditorPanelExitsComponent {
     );
     this.subscriptions.push(
       this._gameEditorService.selectedAreaIdObs.subscribe((data: any) => {
-        console.log('SUBSCRIPTION: selectedAreaId', data);
         if (this.selectedAreaId !== data) {
           this.selectedAreaId = data;
           this.exits = this._gameEditorService.getExitsForCurrentArea();

--- a/src/app/features/editor/ui/pages/editor-game/editor-game.component.ts
+++ b/src/app/features/editor/ui/pages/editor-game/editor-game.component.ts
@@ -99,19 +99,18 @@ export class EditorGameComponent {
 
   handleSubNavClick(slug: string) {
     this._gameEditorService.selectExit('');
-    console.log('EXIT NOW EMPTY 2');
     this._gameEditorService.selectItem('');
     this.subNavCurrent = slug;
   }
 
   handleSelectItem(id: string) {
-    console.log('HANDLE ITEM SELECT FROM PAGE', id);
+    this._gameEditorService.selectExit('');
     this._gameEditorService.selectItem(id);
     this.subNavCurrent = 'items';
   }
 
   handleSelectExit(id: string) {
-    console.log('HANDLE EXIT SELECT FROM PAGE', id);
+    this._gameEditorService.selectItem('');
     this._gameEditorService.selectExit(id);
     this.subNavCurrent = 'exits';
   }


### PR DESCRIPTION
- When an editor clicks directly on an exit, we should reset the selection for items
- When an editor clicks directly on an item, we should reset the selection for exits