### PR TITLE
feat: TQ17 allow exits to have no destination exit ID

### DIFF
--- a/src/app/features/editor/ui/components/editor-panel-exits/editor-panel-exits.component.ts
+++ b/src/app/features/editor/ui/components/editor-panel-exits/editor-panel-exits.component.ts
@@ -52,9 +52,12 @@ export class EditorPanelExitsComponent {
       .getDestinationAreasListOptions()
       .filter((item) => item.value !== this.selectedAreaId);
 
-    this.exitsListOptions = this._gameEditorService
-      .getDestinationExitsListOptions(this.inputExitDestination)
-      .filter((item) => item.value !== this.selectedExitId);
+    this.exitsListOptions = [
+      { value: '', label: 'None' },
+      ...this._gameEditorService
+        .getDestinationExitsListOptions(this.inputExitDestination)
+        .filter((item) => item.value !== this.selectedExitId),
+    ];
   }
 
   updateExitPositionLockouts() {

--- a/src/app/features/game/services/game-service/game-service.service.ts
+++ b/src/app/features/game/services/game-service/game-service.service.ts
@@ -40,6 +40,17 @@ export class GameService {
     this.gameROM.next(nextGameROM);
     this.initGameState(nextGameROM);
   }
+
+  testSetValue(key: string, value: unknown): void {
+    switch (key) {
+      case 'movementOptions':
+        this.movementOptions.next(value as MovementOptions);
+        break;
+      default:
+        break;
+    }
+  }
+
   calculateMovementOptions(
     nextGameROM: GameROM,
     nextGameState: GameState
@@ -185,13 +196,13 @@ export class GameService {
     }
 
     const destinationFacing = this.getOppositeDirection(
-      destinationExit.direction
+      this.getOppositeDirection(destinationExit.direction)
     );
 
     this.isLockedOut.next(true);
 
     // animate player exit
-    nextGameState.player.facing = exit.direction;
+    nextGameState.player.facing = destinationFacing;
     this.gameState.next({
       ...nextGameState,
       player: {


### PR DESCRIPTION
### TQ17: Game - Exits with No Destination Exit

- Branch: TQ17-game-exits-no-destination-exit
- [x] Allow exit dest exit “none”
- [x] Service: when no exit, place in first walkable square
