### PR TITLE
feat:TQ18 Display item in bubble when player is in same cell

### DIFF
--- a/src/app/features/game/ui/components/area-exit/area-exit.component.html
+++ b/src/app/features/game/ui/components/area-exit/area-exit.component.html
@@ -32,16 +32,4 @@
     (onClick)="handleClick()"
   />
   }
-
-  <!-- @if (isClickable) {
-  <svg></svg>
-  <button
-    role="button"
-    type="button"
-    [attr.aria-label]="ariaLabel"
-    (click)="handleClick()"
-    class="exit-button"
-    [style.z-index]="position.z + 10"
-  ></button>
-  } -->
 </div>

--- a/src/app/features/game/ui/components/area-item/area-item.component.css
+++ b/src/app/features/game/ui/components/area-item/area-item.component.css
@@ -1,4 +1,29 @@
 .area-item {
   position: absolute;
   pointer-events: none;
+  transform: translateY(0);
+  transition: 0.3s transform ease-in-out;
+  &.near-player {
+    transform: translateY(-70%);
+    &.highlight-below {
+      transform: translateY(50%);
+    }
+  }
+}
+.highlighted-object {
+  z-index: 0;
+  opacity: 0;
+  background-color: var(--color-gray-900);
+  border: 2px solid var(--color-gray-100);
+  border-radius: 100%;
+  width: 66%;
+  height: 66%;
+  position: absolute;
+  left: 16.5%;
+  top: 32%;
+  &.active-highlight {
+    transition: 0.3s opacity ease-in-out;
+    opacity: 0.6;
+    pointer-events: all;
+  }
 }

--- a/src/app/features/game/ui/components/area-item/area-item.component.html
+++ b/src/app/features/game/ui/components/area-item/area-item.component.html
@@ -1,11 +1,19 @@
 <div
   [style.width]="width"
   [style.height]="width"
-  [style.z-index]="positionStyle.z"
-  class="area-item"
+  [style.z-index]="isNearPlayer && !isLockedOut ? 999 : positionStyle.z"
+  class="area-item {{ isNearPlayer && !isLockedOut ? 'near-player' : '' }} {{
+    shouldDisplauHighlightBelow ? 'highlight-below' : ''
+  }}"
   [style.bottom]="positionStyle.bottom"
   [style.left]="positionStyle.left"
 >
+  <div
+    aria-hidden="=true"
+    class="highlighted-object {{
+      isNearPlayer && !isLockedOut ? 'active-highlight' : ''
+    }}"
+  ></div>
   @if (item.itemType === 'key-silver') {
   <app-svg-item-key />
   } @else if (item.itemType === 'coins-25') {
@@ -15,7 +23,7 @@
     class="absolute top-[45%] left-[30%] w-[40%] h-[40%] bg-transparent rounded-full z-index-[100] border-4 border-primary border-dashed ring-2 ring-offset-2 ring-offset-primaryDarker ring-primaryDark"
     aria-hidden="true"
   ></div>
-  } @if (isClickable) {
+  } @if (isNearPlayer && !isLockedOut) {
   <button
     role="button"
     type="button"

--- a/src/app/features/game/ui/components/area-item/area-item.component.ts
+++ b/src/app/features/game/ui/components/area-item/area-item.component.ts
@@ -19,8 +19,8 @@ import { SvgItemKeyComponent } from './items/svg-item-key/svg-item-key.component
 export class AreaItemComponent {
   @Input('item') item: GameItem = defaultItem;
   @Input('isEditorSelected') isEditorSelected: boolean = false;
-  @Input('isClickable') isClickable: boolean = false;
   @Input('isNearPlayer') isNearPlayer: boolean = false;
+  @Input('isLockedOut') isLockedOut: boolean = false;
   @Output() onClick = new EventEmitter<string>();
 
   gridSize: number = defaultGridSize;
@@ -29,6 +29,7 @@ export class AreaItemComponent {
   bottom: string = '';
   height: string = '0%';
   width: string = '0%';
+  shouldDisplauHighlightBelow: boolean = false;
   positionStyle: AreaPosition = { left: '0', bottom: '0', z: 0 };
   ariaLabel: string = '';
 
@@ -39,6 +40,8 @@ export class AreaItemComponent {
       this.positionStyle = getAreaElementPositionStyle(this.gridSize, y, x, h);
       this.width = `${cellW}%`;
       this.ariaLabel = `Select Item ${this.item.y}_${this.item.x}`;
+      const b = parseFloat(this.positionStyle.bottom.replace('%', ''));
+      this.shouldDisplauHighlightBelow = b > 80;
     }
   }
 
@@ -49,7 +52,7 @@ export class AreaItemComponent {
     this.updateItemProps();
   }
   handleClick() {
-    if (this.isClickable) {
+    if (this.isLockedOut && this.isNearPlayer) {
       this.onClick.emit(this.item.id);
     }
   }

--- a/src/app/features/game/ui/components/game-area/game-area.component.html
+++ b/src/app/features/game/ui/components/game-area/game-area.component.html
@@ -25,7 +25,8 @@
     @for(item of areaItems; track item.id;) {
     <app-area-item
       [item]="item"
-      [isNearPlayer]="getIsNextToPlayer(item.x, item.y)"
+      [isNearPlayer]="getIsNearPlayer(item.x, item.y)"
+      [isLockedOut]="isLockedOut"
     />
     }
 
@@ -33,8 +34,8 @@
     @for(exit of areaExits; track exit.id;) {
     <app-area-exit
       [exit]="exit"
-      [isClickable]="getIsNextToPlayer(exit.x, exit.y)"
-      [isNearPlayer]="getIsNextToPlayer(exit.x, exit.y)"
+      [isClickable]="getIsNearPlayer(exit.x, exit.y)"
+      [isNearPlayer]="getIsNearPlayer(exit.x, exit.y)"
       (onClick)="handleExitClick(exit.id)"
       [isLockedOut]="isLockedOut"
     />

--- a/src/app/features/game/ui/components/game-area/game-area.component.ts
+++ b/src/app/features/game/ui/components/game-area/game-area.component.ts
@@ -98,7 +98,7 @@ export class GameAreaComponent {
     console.log('Item clicked:', itemId);
   }
 
-  getIsNextToPlayer(x: number, y: number): boolean {
+  getIsNearPlayer(x: number, y: number): boolean {
     return this.playerPosition === `${y}_${x}`;
   }
 


### PR DESCRIPTION
### TQ19: Handle player/item overlap

- Branch: TQ19-handle-player-item-overlap
- [x] Display item in bubble if player is on the same square
- [x] If object is above the 20% line, show below player.
- [x] Otherwise show above player.
