### PR TITLE
feat:TQ28: Fix texture alignment on SVG patterns for map cells

### DIFF
--- a/src/app/features/game/ui/components/area-cell/area-cell.component.html
+++ b/src/app/features/game/ui/components/area-cell/area-cell.component.html
@@ -12,6 +12,8 @@
   <app-textures-wall
     [wallType]="cell.wallSouth"
     wallPosition="l"
+    [h]="cell.h"
+    [positionKey]="positionKey"
     [svgPolygonPoints]="svgPolygonPoints"
     [svgViewBox]="svgViewBox"
   />
@@ -21,6 +23,8 @@
   <app-textures-wall
     [wallType]="cell.wallEast"
     wallPosition="r"
+    [h]="cell.h"
+    [positionKey]="positionKey"
     [svgPolygonPoints]="svgPolygonPoints"
     [svgViewBox]="svgViewBox"
   />

--- a/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.html
+++ b/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.html
@@ -11,7 +11,7 @@
     <pattern
       [id]="
         'texture_' +
-        wallType +
+        positionKey +
         '_' +
         wallPosition +
         '_' +
@@ -35,14 +35,14 @@
     <pattern
       [id]="
         'texture_' +
-        wallType +
+        positionKey +
         '_' +
         wallPosition +
         '_' +
         (isFlat ? 'flat' : 'wall')
       "
       x="0"
-      y="0"
+      [attr.y]="textureYOffset"
       width="1"
       height="1"
     >

--- a/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.ts
+++ b/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.ts
@@ -10,15 +10,18 @@ import { Component, Input } from '@angular/core';
 export class TexturesWallComponent {
   @Input('wallType') wallType: string = 'default';
   @Input('wallPosition') wallPosition: string = 'l';
+  @Input('positionKey') positionKey: string = '';
   @Input('svgViewBox') svgViewBox: string = '';
   @Input('svgPolygonPoints') svgPolygonPoints: string[] = [];
   @Input('isFlat') isFlat: boolean = false;
-  h: number = 100;
-  w: number = 100;
+  @Input('h') h: number = 1;
+
+  textureYOffset: number = 0;
   wallTexture: string = '';
 
   updateProps() {
-    this.wallTexture = `url(#texture_${this.wallType}_${this.wallPosition}_${
+    this.textureYOffset = this.h % 2 === 0 ? 0.5 : 0;
+    this.wallTexture = `url(#texture_${this.positionKey}_${this.wallPosition}_${
       this.isFlat ? 'flat' : 'wall'
     })`;
   }


### PR DESCRIPTION
- Fix vertical alignment issue for map cells that are 1 unit apart such as steps.