### PR TITLE
Tq85 quest thumbnails

### DIFF
--- a/api/src/constants.ts
+++ b/api/src/constants.ts
@@ -96,6 +96,11 @@ export const fieldNames: Record<string, FiledDefinition[]> = {
       detailOnly: false,
     },
     {
+      fieldName: 'cover',
+      required: false,
+      detailOnly: false,
+    },
+    {
       fieldName: 'content',
       required: true,
       detailOnly: true,

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,5 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withInMemoryScrolling } from '@angular/router';
 import { routes } from './app.routes';
 import { provideHttpClient } from '@angular/common/http';
 import { provideOAuthClient } from 'angular-oauth2-oidc';
@@ -12,7 +12,10 @@ import { provideToastr } from 'ngx-toastr';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes),
+    provideRouter(
+      routes,
+      withInMemoryScrolling({ scrollPositionRestoration: 'enabled' })
+    ),
     provideHttpClient(),
     provideOAuthClient(),
     AuthProviderService,

--- a/src/app/features/editor/services/game-editor-service/game-editor-service.service.ts
+++ b/src/app/features/editor/services/game-editor-service/game-editor-service.service.ts
@@ -43,6 +43,7 @@ import {
   utilDeleteActor,
   utilUpdateActor,
 } from './utils/actor-utils';
+import { getCoverFromGameContent } from './utils/common-utils';
 
 @Injectable({
   providedIn: 'root',
@@ -808,6 +809,7 @@ export class GameEditorService {
 
   async saveGame(game: QuestROM): Promise<string> {
     const token = this.authProviderService.getToken();
+    const cover = getCoverFromGameContent(game.content);
     if (this.game?.value?.content) {
       const response = await fetch(gamesApiUrl, {
         method: 'PUT',
@@ -817,6 +819,7 @@ export class GameEditorService {
         },
         body: JSON.stringify({
           ...game,
+          cover,
           content: JSON.stringify(this.game.value.content),
         }),
       });

--- a/src/app/features/editor/services/game-editor-service/utils/common-utils.spec.ts
+++ b/src/app/features/editor/services/game-editor-service/utils/common-utils.spec.ts
@@ -1,5 +1,6 @@
-import { findAnOpenCell } from './common-utils';
+import { findAnOpenCell, getDirectionFromString } from './common-utils';
 import questMockData from '@app/features/editor/mocks/game.mock';
+import { Direction } from '@app/features/main/interfaces/enums';
 import { getPositionKeysForGridSize } from '@main/utils';
 
 describe('findAnOpenCell', () => {
@@ -38,5 +39,23 @@ describe('findAnOpenCell', () => {
       selectedAreaId: 'start',
     });
     expect(result).toBe(null);
+  });
+});
+
+describe('getDirectionFromString', () => {
+  it('returns correct direction for valid input', () => {
+    expect(getDirectionFromString('NORTH')).toBe(Direction.NORTH);
+    expect(getDirectionFromString('EAST')).toBe(Direction.EAST);
+    expect(getDirectionFromString('SOUTH')).toBe(Direction.SOUTH);
+    expect(getDirectionFromString('WEST')).toBe(Direction.WEST);
+  });
+
+  it('returns default for invalid input', () => {
+    expect(getDirectionFromString('UP')).toBe(Direction.NORTH);
+    expect(getDirectionFromString('DOWN')).toBe(Direction.NORTH);
+    expect(getDirectionFromString('LEFT')).toBe(Direction.NORTH);
+    expect(getDirectionFromString('RIGHT')).toBe(Direction.NORTH);
+    expect(getDirectionFromString('')).toBe(Direction.NORTH);
+    expect(getDirectionFromString('NORTHEAST')).toBe(Direction.NORTH);
   });
 });

--- a/src/app/features/editor/services/game-editor-service/utils/common-utils.ts
+++ b/src/app/features/editor/services/game-editor-service/utils/common-utils.ts
@@ -1,5 +1,6 @@
 import { Direction } from '@app/features/main/interfaces/enums';
 import { QuestArea, QuestROM } from '@app/features/main/interfaces/types';
+import { logger } from '@app/features/main/utils/logger';
 import { floorDefinitions } from '@content/floor-definitions';
 import { getPositionKeysForGridSize } from '@main/utils';
 
@@ -47,6 +48,22 @@ export const getDirectionFromString = (directionStr: string): Direction => {
     case 'west':
       return Direction.WEST;
     default:
-      throw new Error(`Invalid direction string: ${directionStr}`);
+      logger({
+        type: 'error',
+        message: `Invalid direction string: ${directionStr}`,
+      });
+
+      return Direction.NORTH;
   }
+};
+
+export const getCoverFromGameContent = (
+  content: QuestROM['content']
+): string | undefined => {
+  const areaId = content.player.areaId;
+  const area = content.areas[areaId];
+  if (!area) {
+    return undefined;
+  }
+  return JSON.stringify(area);
 };

--- a/src/app/features/editor/ui/pages/editor-game/editor-game.component.ts
+++ b/src/app/features/editor/ui/pages/editor-game/editor-game.component.ts
@@ -92,6 +92,7 @@ export class EditorGameComponent {
   ];
 
   ngOnInit() {
+    document.body.classList.add('editor');
     this.subscriptions.push(
       this._gameEditorService.gameObs.subscribe((data: QuestROM | null) => {
         const userId = this._authGoogleService.getUserId();
@@ -111,6 +112,7 @@ export class EditorGameComponent {
   }
 
   ngOnDestroy() {
+    document.body.classList.remove('editor');
     this.subscriptions.forEach(sub => sub.unsubscribe());
   }
 

--- a/src/app/features/game/ui/components/area-actor/area-actor.component.html
+++ b/src/app/features/game/ui/components/area-actor/area-actor.component.html
@@ -2,7 +2,7 @@
   class="area-actor group facing-{{actor.facing}} anim-status-{{actor.animStatus.toLocaleLowerCase()}}"
   [style.bottom]="position.bottom" [style.filter]="'brightness(' + (lightLevel * 100) + '%)'"
   [style.left]="position.left" id="area-actor-{{ actor.id }}">
-  @if(healthPercent > 0) {
+  @if(showHealthBar && healthPercent > 0) {
   <div
     class="absolute top-[30%] left-[20%] w-[60%] h-1 pointer-events-none flex bg-gray-800/50 ring-2 ring-gray-800/50">
     <div class="absolute top-0 left-0 h-1 bg-red-500" [attr.style]="`width: ${healthPercent}%`"></div>

--- a/src/app/features/game/ui/components/area-actor/area-actor.component.ts
+++ b/src/app/features/game/ui/components/area-actor/area-actor.component.ts
@@ -34,6 +34,7 @@ export class AreaActorComponent {
   @Input('isLockedOut') isLockedOut: boolean = false;
   @Input('lightLevel') lightLevel: number = 0;
   @Input('playerPosition') playerPosition: string = '-1_-1';
+  @Input('showHealthBar') showHealthBar: boolean = true;
   @Output() onClick = new EventEmitter<string>();
   gridSize: number = defaultGridSize;
 

--- a/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.ts
+++ b/src/app/features/game/ui/components/textures/textures-wall/textures-wall.component.ts
@@ -47,7 +47,7 @@ export class TexturesWallComponent {
 
   updateProps() {
     this.textureYOffset = this.h % 2 === 0 ? 0.055 : 0;
-    this.textureId = `texture_${this.positionKey}_${this.wallPosition}_${this.isFlat ? 'flat' : 'wall'}`;
+    this.textureId = `texture_${this.positionKey}_${this.wallPosition}_${this.wallType}_${this.isFlat ? 'flat' : 'wall'}`;
     this.wallTexture = `url(#${this.textureId})`;
     this.wallProps = this.getWallTextureProps();
   }

--- a/src/app/features/main/interfaces/types.d.ts
+++ b/src/app/features/main/interfaces/types.d.ts
@@ -166,6 +166,7 @@ export type QuestROM = {
   title: string;
   description: string;
   introduction?: string;
+  cover?: string;
   itemStatus: string;
   userId: string;
   username: string;

--- a/src/app/features/main/ui/components/game-link-card/game-link-card.component.html
+++ b/src/app/features/main/ui/components/game-link-card/game-link-card.component.html
@@ -1,6 +1,12 @@
 <div
-  class="flex flex-col h-full gap-4 bg-primaryDarker rounded-md transition-colors border-2 border-primary group-hover:border-gray-300">
+  class="flex flex-col h-full gap-4 bg-gray-900 rounded-md transition-colors border-2 border-primaryDark group-hover:border-gray-300">
   <div class="px-4 py-4 flex flex-col gap-2 border-b-2 border-gray-400 group-hover:border-gray-300 border-dashed">
+
+    @if(!isSkeleton && cover) {
+    <div class="opacity-75 group-hover:opacity-100 transition-opacity">
+      <app-quest-thumbnail [cover]="cover" />
+    </div>
+    }
     <h3 class="text-xl text-2-line-max">
       @if(isSkeleton) {
       <app-skeleton-text [width]="100" />
@@ -25,9 +31,9 @@
     }
   </div>
 
-  <div class="bg-primary">
+  <div class="bg-primaryDark">
     <div
-      class="bg-primary group-hover:bg-gray-300 transition-colors px-4 py-4 flex flex-row justify-between text-sm text-gray-800">
+      class="bg-primaryDark group-hover:bg-gray-300 text-gray-100 group-hover:text-gray-800 transition-colors px-4 py-4 flex flex-row justify-between text-sm">
       @if (isSkeleton) {
       <div class="skeleton-sm">
         <app-skeleton-text [width]="100" />

--- a/src/app/features/main/ui/components/game-link-card/game-link-card.component.ts
+++ b/src/app/features/main/ui/components/game-link-card/game-link-card.component.ts
@@ -1,9 +1,10 @@
 import { Component, Input } from '@angular/core';
 import { SkeletonTextComponent } from '../skeleton-text/skeleton-text.component';
+import { QuestThumbnailComponent } from '../quest-thumbnail/quest-thumbnail.component';
 
 @Component({
   selector: 'app-game-link-card',
-  imports: [SkeletonTextComponent],
+  imports: [SkeletonTextComponent, QuestThumbnailComponent],
   templateUrl: './game-link-card.component.html',
   styleUrl: './game-link-card.component.css',
   standalone: true,
@@ -15,4 +16,5 @@ export class GameLinkCardComponent {
   @Input('description') description: string = '';
   @Input('playCount') playCount: number = 0;
   @Input('completionCount') completionCount: number = 0;
+  @Input('cover') cover: string = '';
 }

--- a/src/app/features/main/ui/components/quest-thumbnail/quest-thumbnail.component.css
+++ b/src/app/features/main/ui/components/quest-thumbnail/quest-thumbnail.component.css
@@ -1,0 +1,7 @@
+.quest-thumbnail {
+  width: 100%;
+  max-width: 90vh;
+  margin: 0 auto;
+  aspect-ratio: 1 / 1;
+  position: relative;
+}

--- a/src/app/features/main/ui/components/quest-thumbnail/quest-thumbnail.component.html
+++ b/src/app/features/main/ui/components/quest-thumbnail/quest-thumbnail.component.html
@@ -1,0 +1,38 @@
+<div class="quest-thumbnail">
+  <div>
+    @if(area) {
+    @for(positionKey of positionKeys; track positionKey;) {
+
+    <!-- MAP -->
+    @if(!area.map[positionKey].isHidden) {
+    <app-area-cell [positionKey]="positionKey" [cellData]="area.map[positionKey]" [lightLevel]="1" />
+    }
+    }
+    <!-- ITEMS -->
+    @for(item of area.items; track item.id;) {
+    <app-area-item [item]="item" [isNearPlayer]="false" [isLockedOut]="true" [lightLevel]="1" />
+    }
+    <!-- PROPS -->
+    @for(prop of area.props; track prop.id;) {
+    <app-area-prop [prop]="prop" [isClickable]="false" [isNearPlayer]="false" [isLockedOut]="true" [lightLevel]="1" />
+    }
+
+    <!-- ACTORS -->
+    @for(actor of area.actors; track actor.id;) {
+    <app-area-actor [actor]="actor" [isClickable]="false" [isEditorMode]="false" [isLockedOut]="true"
+      [showHealthBar]="false" [lightLevel]="1" />
+    }
+
+    @for(exit of area.exits; track exit.id;) {
+    <app-area-exit [exit]="exit" [isClickable]="false" [isNearPlayer]="false" [isLockedOut]="true" [lightLevel]="1" />
+    }
+
+    }
+
+
+
+
+
+
+  </div>
+</div>

--- a/src/app/features/main/ui/components/quest-thumbnail/quest-thumbnail.component.spec.ts
+++ b/src/app/features/main/ui/components/quest-thumbnail/quest-thumbnail.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { QuestThumbnailComponent } from './quest-thumbnail.component';
+
+describe('QuestThumbnailComponent', () => {
+  let component: QuestThumbnailComponent;
+  let fixture: ComponentFixture<QuestThumbnailComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [QuestThumbnailComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(QuestThumbnailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/main/ui/components/quest-thumbnail/quest-thumbnail.component.ts
+++ b/src/app/features/main/ui/components/quest-thumbnail/quest-thumbnail.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input } from '@angular/core';
+import { QuestArea, QuestAreaMap } from '@app/features/main/interfaces/types';
+import { AreaCellComponent } from '@app/features/game/ui/components/area-cell/area-cell.component';
+import { AreaActorComponent } from '@app/features/game/ui/components/area-actor/area-actor.component';
+import { AreaItemComponent } from '@app/features/game/ui/components/area-item/area-item.component';
+import { AreaPropComponent } from '@app/features/game/ui/components/area-prop/area-prop.component';
+import { AreaExitComponent } from '@app/features/game/ui/components/area-exit/area-exit.component';
+import { getPositionKeysForGridSize } from '@app/features/main/utils';
+@Component({
+  selector: 'app-quest-thumbnail',
+  imports: [
+    AreaCellComponent,
+    AreaActorComponent,
+    AreaItemComponent,
+    AreaPropComponent,
+    AreaExitComponent,
+  ],
+  templateUrl: './quest-thumbnail.component.html',
+  styleUrl: './quest-thumbnail.component.css',
+})
+export class QuestThumbnailComponent {
+  @Input('cover') cover: string = '';
+
+  public area?: QuestArea;
+  public positionKeys = getPositionKeysForGridSize();
+
+  ngOnChanges() {
+    if (this.cover) {
+      this.area = JSON.parse(this.cover) as QuestArea;
+    }
+  }
+}

--- a/src/app/features/main/ui/pages/home/home.component.html
+++ b/src/app/features/main/ui/pages/home/home.component.html
@@ -12,8 +12,9 @@
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-8">
         @if (games.length > 0) { @for (game of games; track game.id) {
         <a routerLink="/quest/{{ game.id }}" class="group rounded-md" (mousedown)="handleClickSound()">
-          <app-game-link-card [title]="game.title" [username]="game.username" [description]="game.description"
-            [playCount]="game.playCount" [completionCount]="game.completionCount" [isSkeleton]="false" />
+          <app-game-link-card [cover]="game.cover" [title]="game.title" [username]="game.username"
+            [description]="game.description" [playCount]="game.playCount" [completionCount]="game.completionCount"
+            [isSkeleton]="false" />
         </a>
         } } @else { @for (skeleton of skeletons; track $index) {
         <div class="flex flex-col gap-4">

--- a/src/styles.css
+++ b/src/styles.css
@@ -52,6 +52,8 @@ body {
   color: var(--color-gray-300);
   max-width: 100vw;
   overflow-x: hidden;
+}
+body.editor {
   /* Sticky editor column positioning requires height */
   height: 100vh;
 }


### PR DESCRIPTION
### TQ85: Quest Thumbnails

- BRANCH: TQ85-quest-thumbnails
- [x] Add a cover field to the quest ROM schema
- [x] On save, save start area as string to cover field
- [x] In API support cover save and retrieve for item list, not just detail
- [x] Create thumbnail component to use in homepage game link card
- [x] Add wall type to texture IDs for walls to fix bug with homepage link card thumbnails