### PR TITLE
TQ98 Update exit animations, full screen scroll

### DIFF
--- a/src/app/features/game/services/game-service/game-service.service.ts
+++ b/src/app/features/game/services/game-service/game-service.service.ts
@@ -96,6 +96,9 @@ export class GameService {
   private exitingDirection = new BehaviorSubject<string>('');
   exitingDirectionObs = this.exitingDirection.asObservable();
 
+  private enteringDirection = new BehaviorSubject<string>('');
+  enteringDirectionObs = this.enteringDirection.asObservable();
+
   private playerAnim = new BehaviorSubject<string>('');
   playerAnimObs = this.playerAnim.asObservable();
 
@@ -660,6 +663,8 @@ export class GameService {
     const area = this.getArea(areaId);
     const exit = area?.exits.find(e => e.id === exitId);
     const destinationAreaId = exit?.destinationAreaId;
+    const hasAreaChanged = destinationAreaId !== areaId;
+
     if (!destinationAreaId) {
       return nextGameState;
     }
@@ -689,6 +694,7 @@ export class GameService {
       },
     });
     this.exitingDirection.next(exit.direction);
+
     await this.delay(250);
 
     if (exit?.exitType === 'game-end') {
@@ -696,28 +702,36 @@ export class GameService {
       return nextGameState;
     }
 
-    // fade out
-    this.areaTransitionMode.next('cover');
+    if (hasAreaChanged) {
+      // fade out
+      this.areaTransitionMode.next('cover');
+    }
     await this.delay(250);
 
     // move player to destination position, area, direction
     nextGameState.player.areaId = destinationAreaId;
     nextGameState.player.x = destinationExit?.x;
     nextGameState.player.y = destinationExit?.y;
-    this.exitingDirection.next('');
-
-    await this.delay(250);
-
-    this.calcLightMap(nextGameState);
-
-    this.isLockedOut.next(false);
-    this.areaTransitionMode.next('');
-
     this.setFullWidthOffsetY(
       nextGameState.player.y,
       nextGameState.player.x,
       destinationArea.map
     );
+    this.gameState.next(nextGameState);
+
+    await this.delay(250);
+    this.enteringDirection.next(destinationExit.direction);
+    this.exitingDirection.next('');
+
+    this.calcLightMap(nextGameState);
+
+    this.isLockedOut.next(false);
+    if (hasAreaChanged) {
+      this.areaTransitionMode.next('');
+    }
+
+    await this.delay(250);
+    this.enteringDirection.next('');
     return nextGameState;
   };
 

--- a/src/app/features/game/ui/components/game-area/game-area.component.css
+++ b/src/app/features/game/ui/components/game-area/game-area.component.css
@@ -10,6 +10,9 @@
     width: 100vw;
     bottom: 0;
     transition: bottom 0.5s ease-in-out;
+    &.cut {
+      transition: none;
+    }
   }
 
   .stage-base {

--- a/src/app/features/game/ui/components/game-area/game-area.component.html
+++ b/src/app/features/game/ui/components/game-area/game-area.component.html
@@ -1,4 +1,5 @@
-<div class="game-area-stage" [style.bottom]="isFullWidthMode ? fullWidthOffsetY : 0">
+<div class="game-area-stage {{inhibitFullScreenPanAnimation ? 'cut' : '' }}"
+  [style.bottom]="isFullWidthMode ? fullWidthOffsetY : 0">
   @if(areaMap) {
   <div>
     @for(positionKey of areaDataPositionKeys; track positionKey;) {

--- a/src/app/features/game/ui/components/game-area/game-area.component.ts
+++ b/src/app/features/game/ui/components/game-area/game-area.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, SimpleChanges } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { GameService } from '@app/features/game/services/game-service/game-service.service';
 import {
@@ -58,6 +58,7 @@ export class GameAreaComponent {
   areaLightMap: LightMap = {};
   fullWidthOffsetY: string = '0%';
   public playerPositionForActors: string = '-1_-1';
+  public inhibitFullScreenPanAnimation: boolean = false;
 
   ngOnInit(): void {
     this.subscriptions.push(
@@ -68,6 +69,13 @@ export class GameAreaComponent {
     this.subscriptions.push(
       this._gameService.fullWidthOffsetYObs.subscribe((data: string) => {
         this.fullWidthOffsetY = data;
+        if (this.isFullWidthMode) {
+          console.log(
+            'Setting inhibitFullScreenPanAnimation to true',
+            this.areaTransitionMode
+          );
+          this.inhibitFullScreenPanAnimation = this.areaTransitionMode !== '';
+        }
       })
     );
     this.subscriptions.push(
@@ -160,6 +168,18 @@ export class GameAreaComponent {
     // FUTURE: DIALOG
   }
 
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['isFullWidthMode'] && !changes['isFullWidthMode'].firstChange) {
+      console.log(
+        'isFullWidthMode changed, setting inhibitFullScreenPanAnimation to',
+        this.areaTransitionMode !== ''
+      );
+      this.inhibitFullScreenPanAnimation = true;
+      setTimeout(() => {
+        this.inhibitFullScreenPanAnimation = false;
+      }, 250);
+    }
+  }
   ngOnDestroy() {
     this.subscriptions.forEach(sub => sub.unsubscribe());
   }

--- a/src/app/features/game/ui/components/game-player/game-player.component.css
+++ b/src/app/features/game/ui/components/game-player/game-player.component.css
@@ -4,6 +4,9 @@
 
   transform: translate(0, 0);
   transition: 0.05s all linear;
+  &.cut {
+    transition: none;
+  }
 
   &.anim-status-attacking {
     &.facing-north {
@@ -28,21 +31,87 @@
 }
 
 .player-position-inner {
-  transition: 0.25s transform ease-in-out;
+  animation: none;
 }
 
 .exit-direction-north {
+  animation: exit-north 0.25s forwards;
   transform: translate(15%, -8%);
 }
 
 .exit-direction-south {
+  animation: exit-south 0.25s forwards;
   transform: translate(-15%, 8%);
 }
 
 .exit-direction-east {
+  animation: exit-east 0.25s forwards;
   transform: translate(15%, 8%);
 }
 
 .exit-direction-west {
+  animation: exit-west 0.25s forwards;
+  transform: translate(-15%, -8%);
+}
+
+@keyframes exit-north {
+  0% {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(15%, -8%);
+    opacity: 0;
+  }
+}
+@keyframes exit-south {
+  0% {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-15%, 8%);
+    opacity: 0;
+  }
+}
+@keyframes exit-east {
+  0% {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(15%, 8%);
+    opacity: 0;
+  }
+}
+
+@keyframes exit-west {
+  0% {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-15%, -8%);
+    opacity: 0;
+  }
+}
+
+.entering-direction-north {
+  animation: exit-north 0.25s reverse;
+  transform: translate(15%, -8%);
+}
+
+.entering-direction-south {
+  animation: exit-south 0.25s reverse;
+  transform: translate(-15%, 8%);
+}
+
+.entering-direction-east {
+  animation: exit-east 0.25s reverse;
+  transform: translate(15%, 8%);
+}
+
+.entering-direction-west {
+  animation: exit-west 0.25s reverse;
   transform: translate(-15%, -8%);
 }

--- a/src/app/features/game/ui/components/game-player/game-player.component.html
+++ b/src/app/features/game/ui/components/game-player/game-player.component.html
@@ -1,7 +1,7 @@
 <div [style.width]="width" [style.height]="width" [style.z-index]="positionStyle.z"
   class="player-position facing-{{playerFacing}} anim-status-{{ playerAnim.toLowerCase() }}"
   [style.bottom]="positionStyle.bottom" [style.left]="positionStyle.left">
-  <div class="player-position-inner {{ exitTransitionClass }}">
+  <div class="player-position-inner {{ exitTransitionClass }} {{ enteringTransitionClass }}">
     <app-svg-player [playerFacing]="playerFacing" [playerAnim]="playerAnim" />
     <div class="absolute top-8 left-0 w-full flex justify-center text-wite-100"></div>
   </div>

--- a/src/app/features/game/ui/components/game-player/game-player.component.ts
+++ b/src/app/features/game/ui/components/game-player/game-player.component.ts
@@ -22,11 +22,12 @@ export class GamePlayerComponent {
   @Input('playerFacing') playerFacing: string = 'north';
   @Input('cellData') cellData: QuestAreaMapCell | null = null;
 
-  h: number = 0;
-  positionStyle: AreaPosition = { left: '0', bottom: '0', z: 0 };
-  width: string = '0%';
-  exitTransitionClass = '';
-  playerAnim = '';
+  public h: number = 0;
+  public positionStyle: AreaPosition = { left: '0', bottom: '0', z: 0 };
+  public width: string = '0%';
+  public exitTransitionClass = '';
+  public enteringTransitionClass = '';
+  public playerAnim = '';
 
   constructor(private _gameService: GameService) {}
 
@@ -55,6 +56,11 @@ export class GamePlayerComponent {
     this.subscriptions.push(
       this._gameService.exitingDirectionObs.subscribe((data: string) => {
         this.exitTransitionClass = `exit-direction-${data}`;
+      })
+    );
+    this.subscriptions.push(
+      this._gameService.enteringDirectionObs.subscribe((data: string) => {
+        this.enteringTransitionClass = `entering-direction-${data}`;
       })
     );
     this.subscriptions.push(


### PR DESCRIPTION
- Do not show fade cover when the exit sends the player to another exit in the same room.
- Update exit animation to avoid mid-transition jumps.
- Prevent full screen pan from scrolling during exit and after full screen toggle.