### PR TITLE
TQ100 Fix red hurt screen scroll in full-width mode

### DIFF
--- a/src/app/features/game/ui/components/area-item/area-item.component.css
+++ b/src/app/features/game/ui/components/area-item/area-item.component.css
@@ -22,11 +22,6 @@
   background-color: var(--color-gray-900);
   border: 2px solid var(--color-gray-100);
   border-radius: 100%;
-  width: 66%;
-  height: 66%;
-  position: absolute;
-  left: 16.5%;
-  top: 32%;
   &.active-highlight {
     transition: 0.3s opacity ease-in-out;
     opacity: 0.5;

--- a/src/app/features/game/ui/components/area-item/area-item.component.html
+++ b/src/app/features/game/ui/components/area-item/area-item.component.html
@@ -3,7 +3,7 @@
     isNearPlayer && !isLockedOut ? 'near-player' : ''
   }} {{ shouldDisplayHighlightBelow ? 'highlight-below' : '' }}" [style.bottom]="positionStyle.bottom"
   [style.left]="positionStyle.left" [style.filter]="'brightness(' + (lightLevel * 100) + '%)'">
-  <div aria-hidden="=true" class="highlighted-object {{
+  <div aria-hidden="=true" class="highlighted-object absolute w-[66%] h-[66%] left-[16.5%] top-[32%] {{
       isNearPlayer && !isLockedOut ? 'active-highlight' : ''
     }}"></div>
   @if (itemType.startsWith('key-')) {

--- a/src/app/features/game/ui/components/game-area/game-area.component.ts
+++ b/src/app/features/game/ui/components/game-area/game-area.component.ts
@@ -42,21 +42,21 @@ export class GameAreaComponent {
   private subscriptions: Subscription[] = [];
   constructor(private _gameService: GameService) {}
 
-  areaId: string | null = null;
-  areaMap: QuestAreaMap | null = null;
-  areaExits: QuestAreaExit[] = [];
-  areaItems: QuestItem[] = [];
-  areaProps: QuestProp[] = [];
-  areaActors: QuestActor[] = [];
-  movementOptions: { [key: string]: string[] } = {};
-  movementOptionsKeys: string[] = [];
-  areaDataPositionKeys: string[] = [];
-  playerPosition: string = '0_0';
-  playerFacing: string = 'north';
-  isLockedOut: boolean = false;
-  areaTransitionMode: string = 'cover';
-  areaLightMap: LightMap = {};
-  fullWidthOffsetY: string = '0%';
+  public areaId: string | null = null;
+  public areaMap: QuestAreaMap | null = null;
+  public areaExits: QuestAreaExit[] = [];
+  public areaItems: QuestItem[] = [];
+  public areaProps: QuestProp[] = [];
+  public areaActors: QuestActor[] = [];
+  public movementOptions: { [key: string]: string[] } = {};
+  public movementOptionsKeys: string[] = [];
+  public areaDataPositionKeys: string[] = [];
+  public playerPosition: string = '0_0';
+  public playerFacing: string = 'north';
+  public isLockedOut: boolean = false;
+  public areaTransitionMode: string = 'cover';
+  public areaLightMap: LightMap = {};
+  public fullWidthOffsetY: string = '0%';
   public playerPositionForActors: string = '-1_-1';
   public inhibitFullScreenPanAnimation: boolean = false;
 

--- a/src/app/features/game/ui/pages/game/game.component.css
+++ b/src/app/features/game/ui/pages/game/game.component.css
@@ -19,7 +19,7 @@
   }
 }
 
-.shake-screen {
+.shake-screen .game-wrap {
   animation: shake 0.2s forwards;
 }
 
@@ -37,6 +37,6 @@
     transform: translateY(2px);
   }
   100% {
-    transform: translateY(0);
+    transform: translateX(0);
   }
 }

--- a/src/app/features/game/ui/pages/game/game.component.html
+++ b/src/app/features/game/ui/pages/game/game.component.html
@@ -41,7 +41,7 @@
         <div
           class="absolute z-[110] top-0 {{isFullWidthMode ? 'right-4' : 'right-0'}} flex flex-col gap-1 items-start justify-end">
           <div class="text-sm w-full text-right">
-            <app-health-hud [health]="playerHealth" [maxHealth]="playerMaxHealth" />
+            <app-health-hud [health]="playerHealth ?? 0" [maxHealth]="playerMaxHealth" />
           </div>
           <div class="text-sm w-full text-right">
             TURNS:

--- a/src/app/features/game/ui/pages/game/game.component.ts
+++ b/src/app/features/game/ui/pages/game/game.component.ts
@@ -65,7 +65,7 @@ export class GameComponent {
   public score: number = 0;
   public gameId: string = '';
   public numTurns: number = 0;
-  public playerHealth: number = 0;
+  public playerHealth: number | null = null;
   public playerMaxHealth: number = 0;
   public showGame: boolean = false;
   public showPlayerHurt: boolean = false;
@@ -165,7 +165,10 @@ export class GameComponent {
         this.weaponOptions = getWeaponOptions(data?.player.inventory);
 
         if (data?.player?.health !== undefined) {
-          if (data.player.health < this.playerHealth) {
+          if (
+            this.playerHealth !== null &&
+            data.player.health < this.playerHealth
+          ) {
             this.showPlayerHurt = true;
             setTimeout(() => {
               this.showPlayerHurt = false;


### PR DESCRIPTION
- Full width mode: Fix red hurt display, the We see the very top of the screen for a split second.
- Hurt animation plays when we load an existing game
- Full width mode: item pop over geometry is weird